### PR TITLE
Enable ECS Metadata in Container

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -16,6 +16,7 @@ resource "aws_launch_configuration" "ecs" {
 #!/bin/bash
 
 echo ECS_CLUSTER=${aws_ecs_cluster.main.name} >> /etc/ecs/ecs.config
+echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 ${var.additional_bash_user_data}
 
 EOF


### PR DESCRIPTION
See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html

This will let us put some info about infrastructure into log messages.