### PR TITLE
Add a ECS Health Check Lambda

### DIFF
--- a/ecs_health.tf
+++ b/ecs_health.tf
@@ -1,0 +1,79 @@
+locals {
+  ecs_health_name = "ecs-health-${var.app}-${var.env}-${random_string.health-task-rando.result}"
+}
+
+resource "random_string" "health-task-rando" {
+  length  = 4
+  special = false
+}
+
+module "ecs-health" {
+  source             = "git@github.com:AgencyPMG/terraform-lambda-function.git"
+  app                = local.ecs_health_name
+  env                = var.env
+  name               = local.ecs_health_name
+  runtime            = "python3.7"
+  handler            = "main.handle"
+  path               = "${path.module}/ecs_health"
+  subnet_ids         = local.subnet_ids
+  security_group_ids = [aws_security_group.server.id]
+  function_version   = filemd5("${path.module}/ecs_health/main.py")
+  timeout            = "120"
+
+  environment = {
+    CLUSTER_NAME = aws_ecs_cluster.main.name
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "ecs-health" {
+  name                = local.ecs_health_name
+  schedule_expression = "rate(20 minutes)"
+}
+
+resource "aws_lambda_permission" "ecs-health" {
+  statement_id  = "AllowExecFromScheduledEvent"
+  principal     = "events.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = module.ecs-health.function_name
+  source_arn    = aws_cloudwatch_event_rule.schedule.arn
+}
+
+resource "aws_cloudwatch_event_target" "ecs-health" {
+  rule = aws_cloudwatch_event_rule.schedule.name
+  arn  = module.ecs-health.function_arn
+}
+
+data "aws_iam_policy_document" "ecs-health-lambda" {
+  statement {
+    sid    = "AllowDescribeContainerInstance"
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeContainerInstances",
+      "ecs:ListContainerInstances",
+    ]
+    resources = [
+      aws_ecs_cluster.main.arn,
+    ]
+  }
+
+  statement {
+    sid     = "AllowSetInstanceHealth"
+    effect  = "Allow"
+    actions = ["autoscaling:SetInstanceHealth"]
+    # doesn't seem to be a way to limit this to a single auto scaling group...
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecs-health-lambda" {
+  name        = local.ecs_health_name
+  policy      = data.aws_iam_policy_document.ecs-health-lambda.json
+  description = "Allows lambda to describe container instances and set instance health"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-health-lambda" {
+  role       = module.ecs-drain.role_name
+  policy_arn = aws_iam_policy.ecs-health-lambda.arn
+}

--- a/ecs_health/Makefile
+++ b/ecs_health/Makefile
@@ -1,0 +1,2 @@
+deps:
+	@echo No dependencies

--- a/ecs_health/main.py
+++ b/ecs_health/main.py
@@ -1,0 +1,90 @@
+"""
+ECS Instance Health
+~~~~~~~~~~~~~~~~~~~
+
+It's not uncoming for the ECS service to "loose touch" with an EC2 instance. When
+that happens ECS can't place tasks, but the auto scaling group still views the
+instance as healthy and doesn't remove it.
+
+This fixes that problem. It looks up container instances and if the agent is no
+longer connected marks them as unhealthy.
+"""
+
+import logging
+import os
+import boto3 as aws
+import pprint
+
+
+def create_default_logger():
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+class EcsInstanceHealth(object):
+    _logger = None
+
+    #: An AWS session object.
+    _session = None
+
+    def __init__(self, logger=None, session=None):
+        self._logger = logger or create_default_logger()
+        self._session = session or aws.Session()
+
+
+    def __call__(self, cluster):
+        unhealthy = list(filter(lambda i: self._is_unhealthy(i), self._find_instances(cluster)))
+        pprint.pprint(unhealthy)
+        if not unhealthy:
+            return self._logger.info('No unhealthy instances found')
+
+        autos = self._session.client('autoscaling')
+        for uh in unhealthy:
+            uhid = uh['ec2InstanceId']
+            self._logger.info('marking %s as unhealthy', uhid)
+            try:
+                autos.set_instance_health(
+                    InstanceId=uhid,
+                    HealthStatus='Unhealthy',
+                    ShouldRespectGracePeriod=False
+                )
+            except Exception as e:
+                self._logger.exception(e)
+
+    def _find_instances(self, cluster):
+        ecs = self._session.client('ecs')
+        ids = ecs.list_container_instances(cluster=cluster, maxResults=100)
+        resp = ecs.describe_container_instances(
+            cluster=cluster,
+            containerInstances=ids['containerInstanceArns']
+        )
+
+        return resp['containerInstances']
+
+    def _is_unhealthy(self, instance):
+        """
+        Any instance not in an `ACTIVE` state isn't eligible to be unhealthy.
+
+        Otherwise our health check depends on if the agent is connected.
+        """
+        if 'ACTIVE' != instance['status']:
+            return False
+
+        return not instance['agentConnected']
+
+
+def handle(event, context=None):
+    logger = create_default_logger()
+    ecscheck = EcsInstanceHealth(logger=logger)
+    try:
+        ecscheck(os.environ['CLUSTER_NAME'])
+    except Exception as e:
+        logger.exception(e)
+    finally:
+        logging.shutdown()
+
+
+if __name__ == '__main__':
+    handle({})


### PR DESCRIPTION
This looks at the ECS instance running in the cluster and sets any
instances that have disconnected as unhealthy.