### PR TITLE
Use cluster name for task check lambda

### DIFF
--- a/check_tasks.tf
+++ b/check_tasks.tf
@@ -19,9 +19,8 @@ module "check-ecs-tasks" {
   security_group_ids = [aws_security_group.server.id]
   function_version   = filemd5("${path.module}/check_tasks/main.py")
   environment = {
-    APP_NAME        = var.app
-    APP_ENVIRONMENT = var.env
-    SNS_TOPIC_ARN   = aws_sns_topic.ecs-task-alerts.arn
+    CLUSTER_NAME  = aws_ecs_cluster.main.name
+    SNS_TOPIC_ARN = aws_sns_topic.ecs-task-alerts.arn
   }
 }
 

--- a/check_tasks/main.py
+++ b/check_tasks/main.py
@@ -102,10 +102,8 @@ def record_task_counts(clustername):
     print(families)
 
 def handle(event, context=None):
-    appname = os.environ['APP_NAME']
-    appenv = os.environ['APP_ENVIRONMENT']
+    clustername = os.environ['CLUSTER_NAME']
 
-    clustername = "%s%s" % (appname, appenv)
     check_running_tasks(clustername)
     record_task_counts(clustername)
 


### PR DESCRIPTION
forklift constructs ecs cluster names with additional info beyond app and env name, so this updates the task check lambda to use the cluster name as provided